### PR TITLE
fix: getUserGameLeaderboards export and required username

### DIFF
--- a/src/leaderboard/getUserGameLeaderboards.ts
+++ b/src/leaderboard/getUserGameLeaderboards.ts
@@ -58,13 +58,11 @@ import type {
  */
 export const getUserGameLeaderboards = async (
   authorization: AuthObject,
-  payload: { gameId: ID; username?: string; offset?: number; count?: number }
+  payload: { gameId: ID; username: string; offset?: number; count?: number }
 ): Promise<UserGameLeaderboards> => {
   const queryParams: Record<string, any> = {};
   queryParams.i = payload.gameId;
-  if (payload?.username) {
-    queryParams.u = payload.username;
-  }
+  queryParams.u = payload.username;
   if (payload?.offset) {
     queryParams.o = payload.offset;
   }

--- a/src/leaderboard/index.ts
+++ b/src/leaderboard/index.ts
@@ -1,2 +1,3 @@
 export * from "./getLeaderboardEntries";
+export * from "./getUserGameLeaderboards";
 export * from "./models";


### PR DESCRIPTION
bug from my old PR https://github.com/RetroAchievements/api-js/pull/122

- adds export for `getUserGameLeaderboards`
- adds required `username` field to `getUserGameLeaderboards`

https://github.com/RetroAchievements/api-docs/pull/93