### PR TITLE
fix(serialize): add true as an accepted value for bool

### DIFF
--- a/src/utils/internal/serializeProperties.test.ts
+++ b/src/utils/internal/serializeProperties.test.ts
@@ -114,28 +114,34 @@ describe("Util: serializeProperties", () => {
     });
   });
 
-  it("can be instructed to map values of certain keys to booleans", () => {
-    // ARRANGE
-    const originalObject = {
-      UserName: "xelnia",
-      HardcoreMode: "0",
-      Metadata: {
-        IsCoolGuy: "1",
-      },
-    };
+  it.each([
+    { hardcoreMode: "0", isCoolGuy: "1" },
+    { hardcoreMode: false, isCoolGuy: true },
+  ])(
+    "can be instructed to map values of certain keys to booleans such as the value '$hardcoreMode' and '$isCoolGuy'",
+    ({ hardcoreMode, isCoolGuy }) => {
+      // ARRANGE
+      const originalObject = {
+        UserName: "xelnia",
+        HardcoreMode: hardcoreMode,
+        Metadata: {
+          IsCoolGuy: isCoolGuy,
+        },
+      };
 
-    // ACT
-    const sanitizedObject = serializeProperties(originalObject, {
-      shouldMapToBooleans: ["HardcoreMode", "IsCoolGuy"],
-    });
+      // ACT
+      const sanitizedObject = serializeProperties(originalObject, {
+        shouldMapToBooleans: ["HardcoreMode", "IsCoolGuy"],
+      });
 
-    // ASSERT
-    expect(sanitizedObject).toEqual({
-      userName: "xelnia",
-      hardcoreMode: false,
-      metadata: {
-        isCoolGuy: true,
-      },
-    });
-  });
+      // ASSERT
+      expect(sanitizedObject).toEqual({
+        userName: "xelnia",
+        hardcoreMode: false,
+        metadata: {
+          isCoolGuy: true,
+        },
+      });
+    }
+  );
 });

--- a/src/utils/internal/serializeProperties.ts
+++ b/src/utils/internal/serializeProperties.ts
@@ -33,7 +33,11 @@ export const serializeProperties = (
         if (originalValue === null) {
           sanitizedValue = null;
         } else {
-          sanitizedValue = String(originalValue) === "1" ? true : false;
+          const originalValueAsString = String(originalValue);
+          sanitizedValue =
+            originalValueAsString === "1" || originalValueAsString === "true"
+              ? true
+              : false;
         }
       }
 


### PR DESCRIPTION
When I was working on `getUsersFollowingMe`, I noticed that `shouldMapToBooleans` was not properly mapping `true` or `false` when the API responds with those values. This bug remained undetected since almost all responses from RA's API return either a "1" or "0" for a Boolean field. Since `API_GetUsersIFollow.php` and `API_GetUsersFollowingMe.php` return either `true` or `false` for their Boolean fields, the serializer function will always map the value as `false` due to the missing check for `true`. This PR fixes this issue by adding a check for the stringified version of `true`.