### PR TITLE
Change offset and count checks to undefined

### DIFF
--- a/src/achievement/getAchievementUnlocks.ts
+++ b/src/achievement/getAchievementUnlocks.ts
@@ -57,11 +57,11 @@ export const getAchievementUnlocks = async (
 
   const queryParams: Record<string, number | string> = { a: achievementId };
 
-  if (offset) {
+  if (offset !== undefined) {
     queryParams.o = offset;
   }
 
-  if (count) {
+  if (count !== undefined) {
     queryParams.c = count;
   }
 


### PR DESCRIPTION
Since 0 can be a valid value (and is not the default value for count in this case) it is not appropriate to check `count` for truthy/falsy, but the check should be to see if it's defined instead.